### PR TITLE
Raise on negative integer input

### DIFF
--- a/lib/basecustom.rb
+++ b/lib/basecustom.rb
@@ -45,6 +45,7 @@ class BaseCustom
       i_out
     # end input_val.is_a?(String)
     elsif input_val.is_a?(Integer)
+       raise "Negative integers are not supported!" if input_val < 0
        return @BASE_PRIMITIVES_HASH.first[0] if input_val == 0
        number = input_val
        result = ""

--- a/test/bc_test.rb
+++ b/test/bc_test.rb
@@ -30,6 +30,7 @@ class TestBaseCustom < Test::Unit::TestCase
     assert_raise RuntimeError, LoadError do base2.base(:nonexistant); end
     assert_raise RuntimeError, LoadError do base2.base('abc'); end
     assert_raise RuntimeError, LoadError do base2.base(4.5); end
+    assert_raise RuntimeError, LoadError do base2.base(-3); end
     assert_raise RuntimeError, LoadError do BaseCustom.new(%w[:a :b :c]); end
     assert_raise RuntimeError, LoadError do BaseCustom.new(0..9); end
     assert_raise RuntimeError, LoadError do BaseCustom.new(['0','1',2]); end


### PR DESCRIPTION
Passing negative integer input causes infinite loop as `number` will always be negative and never gets to zero
https://github.com/danielpclark/BaseCustom/blob/018e081ad5f5e6b32f7a859365d258c644a29555/lib/basecustom.rb#L49-L54

With that it's better to raise right away. Since other cases also raise `RuntimeError` I used it instead of `ArgumentError` for the sake of consistency.